### PR TITLE
30 change the maximum project number 5 to illimited

### DIFF
--- a/Views/BackupView.axaml
+++ b/Views/BackupView.axaml
@@ -27,6 +27,11 @@
                          SelectionMode="Multiple"
                          SelectionChanged="ProjectsListBox_SelectionChanged"
                          VerticalAlignment="Stretch">
+                         <ListBox.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <VirtualizingStackPanel />
+                            </ItemsPanelTemplate>
+                        </ListBox.ItemsPanel>
                     <ListBox.ItemTemplate>
                         <DataTemplate>
                             <StackPanel>
@@ -48,6 +53,11 @@
                          ItemsSource="{Binding AvailableBackups}"
                          VerticalAlignment="Stretch"
                          SelectionMode="Single">
+                         <ListBox.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <VirtualizingStackPanel />
+                            </ItemsPanelTemplate>
+                        </ListBox.ItemsPanel>
                     <ListBox.ItemTemplate>
                         <DataTemplate>
                             <StackPanel>

--- a/models/modelBackup.cs
+++ b/models/modelBackup.cs
@@ -18,7 +18,7 @@ namespace EasySave.Models
     /// </summary>
     public class ModelBackup
     {
-        private const int MaxProjects = 5;
+        private const int MaxProjects = 999;
         private readonly Dictionary<string, CancellationTokenSource> autoSaveTasks = new();
         private readonly Dictionary<string, BackupState> backupStates = new();
         
@@ -238,7 +238,6 @@ namespace EasySave.Models
                     if (!string.IsNullOrEmpty(lastBackupDir))
                     {
                         await Task.Run(() => this.CopyModifiedFilesWithProgressAsync(sourceDirPath, versionDir, lastBackupDir, state, progressReporter, projectName, isDifferential, stopwatch));
-
                     }
                     else
                     {
@@ -601,7 +600,6 @@ namespace EasySave.Models
         /// Copies only modified files with progress tracking.
         /// </summary>
         private async Task CopyModifiedFilesWithProgressAsync(string sourceDir, string destDir, string lastBackupDir, BackupState state, IProgress<double>? progressReporter = null, string? projectName = null, bool isDifferential = false, Stopwatch? stopwatch = null)
-
         {
             try
             {


### PR DESCRIPTION
This pull request introduces performance improvements and codebase adjustments to the `BackupView` and `ModelBackup` components. The most important changes include enabling virtualization for `ListBox` controls in the UI, increasing the maximum number of projects allowed, and removing unnecessary blank lines in the code for better readability.

### Performance improvements:
* [`Views/BackupView.axaml`](diffhunk://#diff-b9889922c20901c6e494c79276630bb11313dbfed92849b9fb7872180aff564eR30-R34): Added a `VirtualizingStackPanel` to the `ItemsPanel` of two `ListBox` controls to improve UI performance when handling large datasets. [[1]](diffhunk://#diff-b9889922c20901c6e494c79276630bb11313dbfed92849b9fb7872180aff564eR30-R34) [[2]](diffhunk://#diff-b9889922c20901c6e494c79276630bb11313dbfed92849b9fb7872180aff564eR56-R60)

### Codebase adjustments:
* [`models/modelBackup.cs`](diffhunk://#diff-63632a2151fc3b2e354d485fa63bb038eebee0989092ebcd7eeba2190df01a02L21-R21): Increased the `MaxProjects` constant from 5 to 999, allowing users to manage a significantly larger number of projects.
* [`models/modelBackup.cs`](diffhunk://#diff-63632a2151fc3b2e354d485fa63bb038eebee0989092ebcd7eeba2190df01a02L241): Removed redundant blank lines in the `SaveProjectAsync` and `CopyModifiedFilesWithProgressAsync` methods for cleaner code formatting. [[1]](diffhunk://#diff-63632a2151fc3b2e354d485fa63bb038eebee0989092ebcd7eeba2190df01a02L241) [[2]](diffhunk://#diff-63632a2151fc3b2e354d485fa63bb038eebee0989092ebcd7eeba2190df01a02L604)